### PR TITLE
Make possible to use in several cpp fil in the same translation unit.

### DIFF
--- a/inst/include/interrupts.hpp
+++ b/inst/include/interrupts.hpp
@@ -25,7 +25,7 @@ static void chkIntFn(void *dummy) {
 }
 
 // this will call the above in a top-level context so it won't longjmp-out of your context
-bool checkInterrupt() {
+inline bool checkInterrupt() {
 	return (R_ToplevelExec(chkIntFn, NULL) == FALSE);
 }
 

--- a/inst/include/progress.hpp
+++ b/inst/include/progress.hpp
@@ -24,17 +24,17 @@ public:
 
 	 */
 	Progress(unsigned long max, bool display_progress = true) {
-		if ( _monitor_singleton != 0) { // something is wrong, two simultaneous Progress monitoring
+		if ( monitor_singleton() != 0) { // something is wrong, two simultaneous Progress monitoring
 			Rf_error("ERROR: there is already an InterruptableProgressMonitor instance defined");
 		}
-		_monitor_singleton = new InterruptableProgressMonitor(max, display_progress);
+		monitor_singleton() = new InterruptableProgressMonitor(max, display_progress);
 	}
 
 	~Progress() {
 		if ( monitor().is_display_on() && ! monitor().is_aborted() )
 			monitor().end_display();
-		delete _monitor_singleton;
-		_monitor_singleton = 0;
+		delete monitor_singleton();
+		monitor_singleton() = 0;
 	}
 
 public: // ==== USER INTERFACE =====
@@ -77,13 +77,15 @@ public: // ==== USER INTERFACE =====
 	 */
 	static bool check_abort() { return monitor().check_abort(); }
 
+private:
+	static InterruptableProgressMonitor*& monitor_singleton() {
+		static InterruptableProgressMonitor* p = 0;
+		return p;
+	}
+
 public: // ==== OTHER PUBLIC INTERFACE =====
-	static InterruptableProgressMonitor& monitor() { return *_monitor_singleton; }
+	static InterruptableProgressMonitor& monitor() { return *monitor_singleton(); }
 
-private: // ===== INSTANCE VARIABLES
-	static InterruptableProgressMonitor* _monitor_singleton;
 };
-
-InterruptableProgressMonitor* Progress::_monitor_singleton = 0;
 
 #endif


### PR DESCRIPTION
Linker complains with the current version of RcppProgress, because of multiply defined symbols.
