### PR TITLE
remove unnecessary "ERROR: there is already an InterruptableProgressMonitor instance defined"

### DIFF
--- a/inst/include/progress.hpp
+++ b/inst/include/progress.hpp
@@ -31,9 +31,9 @@ public:
 	  bool display_progress = true,
     ProgressBar& pb = default_progress_bar()
   ) {
-    if ( monitor_singleton() != 0) { // something is wrong, two simultaneous Progress monitoring
-      Rf_error("ERROR: there is already an InterruptableProgressMonitor instance defined");
-    }
+    //if ( monitor_singleton() != 0) { // something is wrong, two simultaneous Progress monitoring
+      //Rf_error("ERROR: there is already an InterruptableProgressMonitor instance defined");
+    //}
     monitor_singleton() = new InterruptableProgressMonitor(max, display_progress, pb);
 	}
 


### PR DESCRIPTION
I know that you have added `Progress::cleanup()` to work around this, but that does not work for me, as I do not use `Progress::check_abort()` --- and even if I do, my code does not get there, or not in time (I am not sure why, perhaps because I use a Rcpp module, perhaps because it is not called often enough) --- but either way, there does not seem to be a reason for the error? It all seems to work fine without it. Perhaps a warning instead would be appropriate  (I would prefer not to have a warning).

I first  did 

```
if ( monitor_singleton() != 0) { 
    delete monitor_singleton();
    monitor_singleton() = 0;
}
``` 

But I do not see the point of that.
