### PR TITLE
clean up existing progress bar in constructor

### DIFF
--- a/inst/include/progress.hpp
+++ b/inst/include/progress.hpp
@@ -31,9 +31,7 @@ public:
 	  bool display_progress = true,
     ProgressBar& pb = default_progress_bar()
   ) {
-    if ( monitor_singleton() != 0) { // something is wrong, two simultaneous Progress monitoring
-      Rf_error("ERROR: there is already an InterruptableProgressMonitor instance defined");
-    }
+    cleanup();
     monitor_singleton() = new InterruptableProgressMonitor(max, display_progress, pb);
 	}
 


### PR DESCRIPTION
The constructor will now clean up existing progress bars before trying to create a new one. If the user interrupts from RStudio, C++ cannot clean up the progress bar and it still exists if the function is called again. The issue is discussed in more detail here:  https://github.com/kforner/rcpp_progress/issues/4