### PR TITLE
Fix #25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: packages
 
 pandoc: false
 
-#before_script:
-#  - make tests
+before_script:
+  - make tests
 
 r_github_packages:
   - jimhester/covr

--- a/R/CxxFlags.R
+++ b/R/CxxFlags.R
@@ -1,0 +1,11 @@
+CxxFlags <- function() 
+{
+  path <- tools::file_path_as_absolute(base::system.file("include", package = "RcppProgress"))
+  if (.Platform$OS.type == "windows") {
+    path <- base::normalizePath(path)
+    if (grepl(" ", path, fixed = TRUE)) 
+      path <- utils::shortPathName(path)
+    path <- gsub("\\\\", "/", path)
+  }
+  paste0("-I", path)
+}

--- a/R/wrap_examples.R
+++ b/R/wrap_examples.R
@@ -1,0 +1,47 @@
+load_my_example_pkg <- function(pkg, recompile = TRUE, ...) {
+  if (!requireNamespace("devtools", quietly = TRUE)) {
+    stop("Package devtools must be installed to run unit tests.",
+         call. = FALSE)
+  }
+  path <- system.file(file.path('examples', pkg), package = 'RcppProgress')
+  devtools::load_all(path, quiet = TRUE, recompile = recompile, ...)
+}
+
+get_function_from_pkg <- function(pkg, fun) {
+  get(fun, getNamespace(pkg))
+}
+
+test_sequential <- function(max = 100, nb = 1000, display_progress= TRUE, ...) {
+  pkg <- 'RcppProgressExample'
+  load_my_example_pkg(pkg, ...)
+  fun <- get_function_from_pkg(pkg, 'test_sequential')
+  fun(max, nb, display_progress)
+}
+
+# R wrapper for the example function #2
+test_multithreaded <- function(max = 100, nb = 1000, threads = 0,
+                               display_progress = TRUE, ...)
+{
+  pkg <- 'RcppProgressExample'
+  load_my_example_pkg(pkg, ...)
+  fun <- get_function_from_pkg(pkg, 'test_multithreaded')
+  fun(max, nb, threads, display_progress)
+}
+
+amardillo_multithreaded <- function(max = 100, nb = 1000, threads = 0,
+                                    display_progress = TRUE, ...)
+{
+  testthat::skip_if_not_installed('RcppArmadillo')
+  pkg <- 'RcppProgressArmadillo'
+  load_my_example_pkg(pkg, ...)
+  fun <- get_function_from_pkg(pkg, 'test_multithreaded')
+  fun(max, nb, threads, display_progress)
+}
+
+eta_progress_bar <- function(max = 100, nb = 1000, display_progress = TRUE)
+{
+  pkg <- 'RcppProgressETA'
+  load_my_example_pkg(pkg)
+  fun <- get_function_from_pkg(pkg, 'test_sequential')
+  fun(max, nb, display_progress)
+}

--- a/tests/testthat/test-pkg_examples.R
+++ b/tests/testthat/test-pkg_examples.R
@@ -1,5 +1,3 @@
-source("wrap_examples.R")
-
 context('RcppProgressExample sequential\n')
 
 .test_sequential <- function() {


### PR DESCRIPTION
Please review. 

I finally decided against exporting the functions as they would require documentation then and as the functions are part of the doc themselves, this would make no sense, imho... Hence there is no Roxygen needed.

TODO: 
- [ ] bump version / update NEWS.md
- [ ]  update RcppProgress-package.Rd _Using RcppProgress in your package_
    - `RcppProgress (>= new version)`
    - `MakeVars` is not needed anymore when you use `// [[Rcpp::depends(RcppProgress)]]` (AFAIK)

